### PR TITLE
Converting SSI directives to JINJA2 for DATA and PUBLICATIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ _This project is currently in progress._
     - Make sure node and npm are installed. Check using **node -v** and **npm -v** commands. If not already installed then please install from this website  [node website](https://nodejs.org/en/) <br />
     - **npm install** to install all the node packages (If behind a corporate web proxy please have a look at this website [How to setup Node.js and Npm behind a corporate web proxy](https://jjasonclark.com/how-to-setup-node-behind-web-proxy))<br />
     - **gulp build** command to create a build folder from the src folder files<br />
+    - **gulp build-jinja** command performs build as above then replaces ssi directives with JINJA2 <br />
     - **gulp watch** command to sync changes between the src folder and the build folder on saving the files<br />
     - **gulp clean:build** command to remove the build folder before creating a new build folder<br />
     - **gulp release** command to create a release folder from the build folder files. Please make sure to run the _gulp build_ command before running the _gulp release_ command<br />

--- a/ssi_to_jinja2.py
+++ b/ssi_to_jinja2.py
@@ -1,0 +1,80 @@
+import sys
+import os
+import re
+from tempfile import mkstemp
+from shutil import move
+
+re_ssi = re.compile('<!--#include .*-->')
+re_echo = re.compile('value=".*"')
+re_echo_all = re.compile('<!--#echo.*-->')
+
+#Expecting a path to directory eg /home/user/swe/build/
+rootdir = sys.argv[1]
+for root, subdirs, files in os.walk(rootdir):
+    files = ["{0}{1}{2}".format(root,os.path.sep,s) for s in files]
+    for file_path in files:
+        include_js_snippet = False
+        #Create temp file
+        fh, abs_path = mkstemp()
+        with open(abs_path,'w') as new_file:
+            with open(file_path) as old_file:
+                for line in old_file:
+                    if '<!--#include' in line:
+                        new_file.write(line.replace('<!--#include virtual=','{% include ').replace('-->',' %}'))
+                    elif '<!--#set' in line:
+                        new_file.write(line.replace('<!--#set var="','{% set ').replace('" value=',' = ').replace('-->',' %}'))
+                    elif '<!--#echo' in line:
+                        if 'REQUEST_URI' in line:
+                            if 'value=' in line:
+                                new_file.write(re_echo.sub('value="{{ full_current_url }}"',line))
+                            else:
+                                new_file.write(re_echo_all.sub('{{ full_current_url }}',line))
+                        elif 'VHOST' in line:
+                            if 'value=' in line:
+                                new_file.write(re_echo.sub('value=""',line))
+                            else:
+                                new_file.write(re_echo_all.sub('',line))
+                        elif 'SERVED_BY' in line:
+                            if 'value=' in line:
+                                new_file.write(re_echo.sub('value=""',line))
+                            else:
+                                new_file.write(re_echo_all.sub('',line))
+                        elif 'SERVER_NAME' in line:
+                            if 'value=' in line:
+                                new_file.write(re_echo.sub('value="{{ macro_helpers.portal_type(\'site\')|trim }}.qld.gov.au"',line))
+                            else:
+                                new_file.write(re_echo_all.sub('{{ macro_helpers.portal_type(\'site\')|trim }}.qld.gov.au',line))
+                        elif 'HTTP_REFERER' in line:
+                            if 'value=' in line:
+                                include_js_snippet = True
+                                new_file.write(re_echo.sub('value=""',line))
+                            else:
+                                new_file.write(re_echo_all.sub('',line))
+                        elif 'HTTP_USER_AGENT' in line:
+                            if 'value=' in line:
+                                include_js_snippet = True
+                                new_file.write(re_echo.sub('value=""',line))
+                            else:
+                                new_file.write(re_echo_all.sub('',line))
+                        elif 'var="franchise"' in line:
+                            if 'value=' in line:
+                                new_file.write(re_echo.sub('value="{{ macro_helpers.portal_type(\'site\')|trim }}.qld.gov.au"',line))
+                            else:
+                                new_file.write(re_echo_all.sub('{{ macro_helpers.portal_type(\'site\')|trim }}.qld.gov.au',line))
+                        elif 'var="title"' in line:
+                            if 'value=' in line:
+                                new_file.write(re_echo.sub('value="{{ page_title }}"',line))
+                            else:
+                                new_file.write(re_echo_all.sub('{{ page_title }}',line))
+                        else:
+                            if 'value=' in line:
+                                new_file.write(re_echo.sub('value=""',line))
+                            else:
+                                new_file.write(re_echo_all.sub('',line))
+                    else:
+                        new_file.write(line)
+                if include_js_snippet == True:
+                    new_file.write('{% snippet "snippets/swe_js_includes.html" %}')
+        os.close(fh)
+        os.remove(file_path)
+        move(abs_path, file_path)


### PR DESCRIPTION
Additional build command 'gulp build-jinja' added to GULP.
This has been added because Data & Publications are run on CKAN which uses JINJA2 templating and is not compatible with SSI.
The build-jinja directive looks for the ./build/swe directory and searches every file for Apache SSI directives eg <!--#set and replaces them with the JINJA equivalent.
Build-jinja runs sequentially after a 5 second delay to allow wepack to complete so the build/swe directory exists.

@raymedia @AsifAmin 