### PR TITLE
QOL-1036: Added build handler for relative styles in docs.

### DIFF
--- a/gulp/release-tasks/copy-element.js
+++ b/gulp/release-tasks/copy-element.js
@@ -3,17 +3,11 @@
 module.exports = function (gulp, plugins, config) {
   return function () {
     return config.outputList.map((element) => {
-      let src = [`${config.basepath.build}/${config.output[element].src}/**`];
+      let src = [
+        `${config.basepath.build}/${config.output[element].src}/**`,
+      ].concat(config.release.excludes);
+
       let dest = `${config.basepath.release}/${config.output[element].dest}/`;
-
-      // if (typeof config.output[element].copyElement === 'string') {
-      //   let elementSrc = config.output[element].src;
-      //   src = [`${config.basepath.build}/${elementSrc}/**`];
-      // } else {
-      //   src = [`${config.basepath.build}/${element}/**/*`];
-      // }
-
-      src.concat(config.release.excludes);
 
       // Test if the element is set to deploy this component
       if (config.output[element].copyElement === true) {
@@ -22,13 +16,18 @@ module.exports = function (gulp, plugins, config) {
           regex: new RegExp('<!--#include.*virtual="/assets/includes/', 'g'),
           replacement: '<!--#include virtual="/assets/includes-cdn/',
         };
-        let relLink = {
+        let relSSI = {
           regex: new RegExp('<!--#include.*virtual="/assets/includes', 'g'),
           replacement: '<!--#include virtual="assets/includes',
+        };
+        let relLink = {
+          regex: new RegExp('<link.*href="/assets/', 'g'),
+          replacement: '<link href="assets/',
         };
 
         return gulp.src(src, { dot: true })
           .pipe(plugins.if(config.output[element].includesLocalToCdn === true, plugins.replace(cdn.regex, cdn.replacement)))
+          .pipe(plugins.if(config.output[element].includesRel === true, plugins.replace(relSSI.regex, relSSI.replacement)))
           .pipe(plugins.if(config.output[element].includesRel === true, plugins.replace(relLink.regex, relLink.replacement)))
           .pipe(plugins.include({ hardFail: true }))
           .on('error', console.log)

--- a/gulp/release-tasks/ssi-to-static.js
+++ b/gulp/release-tasks/ssi-to-static.js
@@ -30,13 +30,13 @@ function fromDir (startPath) {
     list.files.forEach(function (file) {  //iterates through list of filtered files
       ssi.compileFile(file, function (err, content) {
         if (err) {
-          console.log(err);
+          console.error(err);
           return;
         }
         var buildFile = file.replace(folder.src, folder.build);  //builds destination filepath
         fsPath.writeFile(buildFile, content, function (err) {
           if (err) {
-            console.log(err);
+            console.error(err);
           } else {
             console.log(buildFile + ' - Done');
           }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,9 +85,7 @@ gulp.task('copy-element', require('./gulp/release-tasks/copy-element')(gulp, plu
 gulp.task('ssi-to-static', (cb) => {
   return gulp.src('', {read: false})
     .pipe(wait(1500)) // FIXME: This is a dodgy way to handle the wait to save files
-    .pipe(plugins.shell([
-      'node gulp/release-tasks/ssi-to-static.js'
-    ]));
+    .pipe(plugins.shell(['node gulp/release-tasks/ssi-to-static.js']));
 });
 
 gulp.task('release', (cb) => {

--- a/src/assets/_project/_blocks/layout/content/options.html
+++ b/src/assets/_project/_blocks/layout/content/options.html
@@ -2,7 +2,7 @@
     <div id="qg-share" class="qg-share"></div>
 
     <div id="qg-feedback-btn">
-        <button class="btn btn-default qg-toggle-btn collapsed" id="page-feedback-useful"
+        <button class="btn btn-default qg-toggle-btn collapsed qg-icon" id="page-feedback-useful"
             data-toggle="collapse"
             data-target="#qg-page-feedback">Feedback</button>
     </div>

--- a/src/docs/components.html
+++ b/src/docs/components.html
@@ -31,7 +31,7 @@
 
     <!--#include virtual="/assets/includes-local/head-assets.html"-->
 
-    <link href="assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+    <link href="/assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
 
 </head>
 

--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -31,7 +31,7 @@
 
 	<!--#include virtual="/assets/includes-local/head-assets.html"-->
 
-	<link href="assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+	<link href="/assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
 
 </head>
 

--- a/src/docs/javascript.html
+++ b/src/docs/javascript.html
@@ -31,7 +31,7 @@
 
     <!--#include virtual="/assets/includes-local/head-assets.html"-->
 
-    <link href="assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+    <link href="/assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
 
 </head>
 

--- a/src/docs/layout.html
+++ b/src/docs/layout.html
@@ -31,7 +31,7 @@
 
     <!--#include virtual="/assets/includes-local/head-assets.html"-->
 
-    <link href="assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+    <link href="/assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
 
 </head>
 

--- a/src/docs/qg-utilities.html
+++ b/src/docs/qg-utilities.html
@@ -31,7 +31,7 @@
 
     <!--#include virtual="/assets/includes-local/head-assets.html"-->
 
-    <link href="assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+    <link href="/assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
 
 </head>
 

--- a/src/docs/styles.html
+++ b/src/docs/styles.html
@@ -31,7 +31,7 @@
 
     <!--#include virtual="/assets/includes-local/head-assets.html"-->
 
-    <link href="assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+    <link href="/assets/_project/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
 
 </head>
 


### PR DESCRIPTION
This isn't as elegant as I'd like, but it handles the docs properly.

Issue:
Assets for docs need to be root relative in build, but relative in release (to work on github.io).

Solution:
Run a conversion on release to change <link href="/assets/ to <link href="assets/ in docs files.